### PR TITLE
Clean up settings page

### DIFF
--- a/client/src/app/settings/settings.page.html
+++ b/client/src/app/settings/settings.page.html
@@ -9,59 +9,63 @@
     <ion-list-header>
       <ion-label color="primary">Telemetry Server</ion-label>
     </ion-list-header>
-    <ion-item>
-      <ion-label>Address</ion-label>
-      <ion-text slot="end">{{ telemetryUrl$ | async }}</ion-text>
-    </ion-item>
-    <ion-item>
-      <ion-label>Username</ion-label>
-      <ion-text slot="end">{{ telemetryUser$ | async }}</ion-text>
-    </ion-item>
-    <ion-item>
-      <ion-label>Status</ion-label>
-      <ion-icon
-        [color]="(telemetryToken$ | async) ? 'primary' : 'medium'"
-        slot="end"
-        name="lock-closed"
-      ></ion-icon>
-      <ion-icon
-        [color]="(tauConnected$ | async) ? 'primary': 'medium'"
-        slot="end"
-        name="wifi"
-      ></ion-icon>
-    </ion-item>
+    <ng-container *ngIf="telemetrySettings$ | async as telemetrySettings">
+      <ion-item>
+        <ion-label>Address</ion-label>
+        <ion-text slot="end">{{ telemetrySettings.url }}</ion-text>
+      </ion-item>
+      <ion-item>
+        <ion-label>Username</ion-label>
+        <ion-text slot="end">{{ telemetrySettings.user }}</ion-text>
+      </ion-item>
+      <ion-item>
+        <ion-label>Status</ion-label>
+        <ion-icon
+          [color]="(telemetrySettings.token) ? 'primary' : 'medium'"
+          slot="end"
+          name="lock-closed"
+        ></ion-icon>
+        <ion-icon
+          [color]="(telemetrySettings.connected) ? 'primary': 'medium'"
+          slot="end"
+          name="wifi"
+        ></ion-icon>
+      </ion-item>
+    </ng-container>
     <ion-item>
       <ion-buttons slot="end">
-        <ion-button (click)="setupTelemetry()">Set Up</ion-button>
+        <ion-button (click)="setup('telemetry')">Set Up</ion-button>
       </ion-buttons>
     </ion-item>
     <ion-list-header>
       <ion-label color="primary">TAU Server</ion-label>
     </ion-list-header>
-    <ion-item>
-      <ion-label>Address</ion-label>
-      <ion-text slot="end">{{ tauUrl$ | async }}</ion-text>
-    </ion-item>
-    <ion-item>
-      <ion-label>Username</ion-label>
-      <ion-text slot="end">{{ tauUser$ | async }}</ion-text>
-    </ion-item>
-    <ion-item>
-      <ion-label>Status</ion-label>
-      <ion-icon
-        [color]="(tauToken$ | async) ? 'primary' : 'medium'"
-        slot="end"
-        name="lock-closed"
-      ></ion-icon>
-      <ion-icon
-        [color]="(tauConnected$ | async) ? 'primary': 'medium'"
-        slot="end"
-        name="wifi"
-      ></ion-icon>
-    </ion-item>
+    <ng-container *ngIf="tauSettings$ | async as tauSettings">
+      <ion-item>
+        <ion-label>Address</ion-label>
+        <ion-text slot="end">{{ tauSettings.url }}</ion-text>
+      </ion-item>
+      <ion-item>
+        <ion-label>Username</ion-label>
+        <ion-text slot="end">{{ tauSettings.user }}</ion-text>
+      </ion-item>
+      <ion-item>
+        <ion-label>Status</ion-label>
+        <ion-icon
+          [color]="(tauSettings.token) ? 'primary' : 'medium'"
+          slot="end"
+          name="lock-closed"
+        ></ion-icon>
+        <ion-icon
+          [color]="(tauSettings.connected) ? 'primary': 'medium'"
+          slot="end"
+          name="wifi"
+        ></ion-icon>
+      </ion-item>
+    </ng-container>
     <ion-item>
       <ion-buttons slot="end">
-        <ion-button (click)="setupTau()">Set Up</ion-button>
+        <ion-button (click)="setup('tau')">Set Up</ion-button>
       </ion-buttons>
     </ion-item>
   </ion-list>

--- a/client/src/app/settings/settings.page.ts
+++ b/client/src/app/settings/settings.page.ts
@@ -11,14 +11,8 @@ import { SetupTelemetryComponent } from './components/setup-telemetry/setup-tele
   styleUrls: ['./settings.page.scss'],
 })
 export class SettingsPage implements OnInit {
-  tauUrl$ = this.auth.tauUrl$;
-  tauUser$ = this.auth.tauUser$;
-  tauToken$ = this.auth.tauToken$;
-  tauConnected$ = this.auth.tauConnected$;
-  telemetryUrl$ = this.auth.telemetryUrl$;
-  telemetryUser$ = this.auth.telemetryUser$;
-  telemetryToken$ = this.auth.telemetryToken$;
-  telemetryConnected$ = this.auth.telemetryConnected$;
+  tauSettings$ = this.auth.tauSettings$;
+  telemetrySettings$ = this.auth.telemetrySettings$;
 
   constructor(
     private storage: StorageService,
@@ -28,27 +22,14 @@ export class SettingsPage implements OnInit {
 
   ngOnInit() {}
 
-  async setupTau() {
-    const modal = await this.modalCtrl.create({
-      component: SetupTauComponent,
-    });
+  async setup(type: 'tau' | 'telemetry') {
+    const component = type === 'tau' ? SetupTauComponent : SetupTelemetryComponent;
+    const modal = await this.modalCtrl.create({ component });
     await modal.present();
     const data = await modal.onDidDismiss();
 
     if (data && data.data) {
-      this.auth.setupTau(data.data);
-    }
-  }
-
-  async setupTelemetry() {
-    const modal = await this.modalCtrl.create({
-      component: SetupTelemetryComponent,
-    });
-    await modal.present();
-    const data = await modal.onDidDismiss();
-
-    if (data && data.data) {
-      this.auth.setupTelemetry(data.data);
+      this.auth.setup(data.data);
     }
   }
 }


### PR DESCRIPTION
- Expose derived Observables for SettingsPage to use so on the template there will only be 2 subscriptions instead of 8.
- Merge `setupTau` and `setupTelemetry` into `setup()` for both `AuthService` and `SettingsPage`